### PR TITLE
Allow to change contract and policy default name

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ let(:expected_attrs) { { band: 'The Chats'} }
 it { assert_fail MyOp, ctx(title: 'Smoko') }
 ```
 
-This will just test that the operation fails instead passing as third argument an array of symbols will also test that specific attribute has an error:
+This will just test that the operation fails instead passing `expected_errors` as an array of symbols will also test that specific attribute has an error:
 
 ```ruby
-assert_fail MyOp, ctx(band: 'Justing Beaver'), [:band] # definitely wrong!!!!
+assert_fail MyOp, ctx(band: 'Justing Beaver'), expected_errors: [:band] # definitely wrong!!!!
 ```
 
 Using the block here will allow to test the error message:
@@ -132,6 +132,8 @@ assert_fail MyOp, ctx(band: 'Justing Beaver') do |result|
   assert_equal 'You cannot listen Justing Beaver', result['contract.default'].errors.messages[:band]
 end
 ```
+
+Change contract name using `contract_name`.
 
 *We will improve this part and allowing to the test message directly without using a block*
 
@@ -147,16 +149,16 @@ include Trailblazer::Test::Operation::PolicyAssertions
 assert_policy_fail(operation, ctx)
 ```
 
-This will test that the operation fails due to a policy failure
+This will test that the operation fails due to a policy failure.
 
 Example:
 ```ruby
 let(:default_params) { { band: 'The Chats'} }
 let(:default_options) { { current_user: user} }
-let(:expected_attrs) { { band: 'The Chats'} }
 
 it { assert_policy_fail MyOp, ctx({title: 'Smoko'}, current_user: another) }
 ```
+Change policy name using `policy_name`.
 
 ## Test Setup
 

--- a/lib/trailblazer/test/operation/assertions.rb
+++ b/lib/trailblazer/test/operation/assertions.rb
@@ -23,8 +23,8 @@ module Trailblazer::Test::Operation
       assert_pass_with_model(operation_class, operation_inputs, expected_model_attributes: expected_attributes, &block)
     end
 
-    def assert_fail(operation_class, operation_inputs, expected_errors = nil, &block)
-      assert_fail_with_model(operation_class, operation_inputs, expected_errors: expected_errors, &block)
+    def assert_fail(operation_class, operation_inputs, expected_errors: nil, contract_name: "default", &block)
+      assert_fail_with_model(operation_class, operation_inputs, expected_errors: expected_errors, contract_name: contract_name, &block)
     end
 
     # @private
@@ -37,14 +37,14 @@ module Trailblazer::Test::Operation
     end
 
     # @private
-    def assert_fail_with_model(operation_class, operation_inputs, expected_errors: nil, &user_block)
+    def assert_fail_with_model(operation_class, operation_inputs, expected_errors: nil, contract_name: raise, &user_block)
       _assert_call(operation_class, operation_inputs, user_block: user_block) do |result|
         assert_equal true, result.failure?
 
         raise ExpectedErrorsTypeError, "expected_errors has to be an Array" unless expected_errors.is_a?(Array)
 
         # only test _if_ errors are present, not the content.
-        errors = result["contract.default"].errors.messages # TODO: this will soon change with the operation Errors object.
+        errors = result["contract.#{contract_name}"].errors.messages # TODO: this will soon change with the operation Errors object.
 
         assert_equal expected_errors.sort, errors.keys.sort
       end

--- a/lib/trailblazer/test/operation/policy_assertions.rb
+++ b/lib/trailblazer/test/operation/policy_assertions.rb
@@ -3,10 +3,10 @@ module Trailblazer::Test::Operation
     include Assertions
     # @needs params_pass
     # @needs options_pass
-    def assert_policy_fail(operation_class, ctx)
+    def assert_policy_fail(operation_class, ctx, policy_name: "default")
       _assert_call(operation_class, ctx, user_block: nil) do |result|
         assert_equal true, result.failure?
-        assert_equal true, result["result.policy.default"].failure?
+        assert_equal true, result["result.policy.#{policy_name}"].failure?
       end
     end
   end

--- a/test/deprecation_test.rb
+++ b/test/deprecation_test.rb
@@ -70,7 +70,7 @@ class DeprecationTest < Minitest::Spec
   describe "Update with invalid data" do
     let(:default_params) { {band: "Rancid"} }
 
-    it { assert_fail Update, ctx(band: "Adolescents"), [:band] }
+    it { assert_fail Update, ctx(band: "Adolescents"), expected_errors: [:band] }
   end
 
   include Trailblazer::Test::Operation::PolicyAssertions

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -42,6 +42,14 @@ Minitest::Spec.class_eval do
     end
   end
 
+  class CustomResult < Result
+    def [](name)
+      return @model if name == :model
+      return @errors if name == "contract.custom"
+      return @errors.policy if name == "result.policy.custom"
+    end
+  end
+
   Errors = Struct.new(:messages, :policy) do
     def errors
       self
@@ -100,6 +108,20 @@ Minitest::Spec.class_eval do
       else
 
         Result.new(false, nil, Errors.new(band: ["must be Rancid"]))
+      end
+    end
+  end
+
+  class CustomUpdate
+    def self.call(params:, current_user:)
+      return CustomResult.new(false, nil, Errors.new(nil, Policy.new(false))) if current_user.name != "allowed"
+
+      if params[:band] == "Rancid"
+        model = Struct.new(:title, :band).new(params[:title].strip, params[:band])
+        CustomResult.new(true, model, nil)
+      else
+
+        CustomResult.new(false, nil, Errors.new(band: ["must be Rancid"]))
       end
     end
   end


### PR DESCRIPTION
Allows to pass a different name to reach `result['contract.custom']` and `result['result.policy.custom']`