### PR TITLE
Improve call and factory helper methods

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ Style/SignalException:
   Exclude:
     - lib/trailblazer/test/operation/assertions.rb
     - lib/trailblazer/test/operation/helper.rb
+    - lib/trailblazer/test/deprecation/operation/helper.rb
 
 Metrics/ParameterLists:
   Exclude:

--- a/README.md
+++ b/README.md
@@ -157,3 +157,53 @@ let(:expected_attrs) { { band: 'The Chats'} }
 
 it { assert_policy_fail MyOp, ctx({title: 'Smoko'}, current_user: another) }
 ```
+
+## Test Setup
+
+It is obviously crucial to test your operation in the correct test enviroment calling operation instead of using `FactoryBot` or simply `Model.create`.
+
+To do so we provide 2 helper methods:
+* `call`: will call the operation and **will not raise** an error in case of failure
+* `factory`: will call the operation and **will raise** an error in case of failure returning also the trace and a validate error message in case exists
+
+### Usage
+
+Add this in your test `_helper.rb`:
+
+```ruby
+include Trailblazer::Test::Operation::Helper
+```
+
+In case you use are Trailblazer v2.0, you need to add this instead:
+
+```ruby
+require "trailblazer/test/deprecation/operation/helper"
+
+include Trailblazer::Test::Deprecation::Operation::Helper
+```
+
+*Same API for both Trailblazer v2.0 and v2.1*
+
+Examples:
+```ruby
+# call
+let(:user) { call(User::Create, params: params)[:model] }
+
+# call with block
+let(:user) do
+  call User::Create, params: params do |result|
+    # run some code to reproduce some async jobs (for example)
+  end[:model]
+end
+
+# factory - this will raise an error if User::Create fails
+let(:user) { factory(User::Create, params: params)[:model] }
+
+# factory - this will raise an error if User::Create fails
+let(:user) do
+  factory User::Create, params: params do |result|
+    # this block will be yield only if User::Create is successful
+    # run some code to reproduce some async jobs (for example)
+  end[:model]
+end
+```

--- a/lib/trailblazer/test/deprecation/operation/helper.rb
+++ b/lib/trailblazer/test/deprecation/operation/helper.rb
@@ -1,0 +1,28 @@
+module Trailblazer::Test
+  module Deprecation
+    module Operation
+      module Helper
+        def call(operation_class, *args, &block)
+          call!(operation_class, args, &block)
+        end
+
+        def factory(operation_class, *args, &block)
+          call!(operation_class, args, raise_on_failure: true, &block)
+        end
+
+        # @private
+        def call!(operation_class, args, raise_on_failure: false)
+          operation_class.(*args).tap do |result|
+            unless result.success?
+              yield result if block_given?
+
+              raise OperationFailedError, "factory(#{operation_class}) failed." if raise_on_failure
+            end
+          end
+        end
+      end
+    end
+
+    class OperationFailedError < RuntimeError; end
+  end
+end

--- a/lib/trailblazer/test/operation/helper.rb
+++ b/lib/trailblazer/test/operation/helper.rb
@@ -1,24 +1,38 @@
-module Trailblazer::Test
-  module Operation
-    module Helper
-      def call(operation_class, *args)
-        call!(operation_class, args)
-      end
+module Trailblazer::Test::Operation
+  module Helper
+    def call(operation_class, **args, &block)
+      call!(operation_class, args, &block)
+    end
 
-      def call!(operation_class, args, raise_on_failure: false)
-        operation_class.(*args).tap do |result|
-          unless result.success?
-            yield result if block_given?
-            raise OperationFailedError, "factory( #{operation_class} ) failed." if raise_on_failure
+    def factory(operation_class, **args, &block)
+      call!(operation_class, args.merge(raise_on_failure: true), &block)
+    end
+
+    # @private
+    def call!(operation_class, raise_on_failure: false, **args)
+      operation_class.trace(**args).tap do |result|
+        unless result.success?
+
+          msg = "factory(#{operation_class}) has failed"
+
+          unless result["contract.default"].nil? # should we allow to change contract name?
+            if result["contract.default"].errors.messages.any?
+              msg += " due to validation errors: #{result["contract.default"].errors.messages}"
+            end
+          end
+
+          if raise_on_failure
+            result.wtf?
+            raise OperationFailedError, msg
           end
         end
-      end
 
-      def factory(operation_class, *args, &block)
-        call!(operation_class, args, raise_on_failure: true, &block)
+        yield result if block_given?
+
+        result
       end
     end
-  end
 
-  class OperationFailedError < RuntimeError; end
+    class OperationFailedError < RuntimeError; end
+  end
 end

--- a/test/deprecation_helper_test.rb
+++ b/test/deprecation_helper_test.rb
@@ -1,0 +1,70 @@
+require "test_helper"
+require "trailblazer/test/deprecation/operation/helper"
+
+class DeprecationHelperTest < Minitest::Spec
+  module Song
+    Result = Struct.new(:input, :success) do
+      def success?;
+        success;
+      end
+    end
+    Update = ->(*args) { Result.new(args, true) }
+    Create = ->(*args) { Result.new(args, false) }
+  end
+
+  class Test < Minitest::Spec
+    include Trailblazer::Test::Deprecation::Operation::Helper
+
+    #:call
+    it do
+      call Song::Update, title: "Shipwreck"
+    end
+    #:call end
+
+    it do
+      call Song::Update, {a: 1}, b: 2
+    end
+
+    it do
+      factory(Song::Update, {})
+    end
+
+    it do
+      assert_raises Trailblazer::Test::Deprecation::OperationFailedError do
+        #:factory
+        factory(Song::Create, title: "Shipwreck")["model"]
+        #:factory end
+      end
+    end
+
+    it do
+      value = nil
+
+      assert_raises Trailblazer::Test::Deprecation::OperationFailedError do
+        #:factory-block
+        factory(Song::Create, title: "Shipwreck") do |result|
+          value = result
+        end
+        #:factory-block end
+      end
+
+      value
+    end
+  end
+
+  it { assert_equal [{title: "Shipwreck"}], Test.new(:a).test_0001_anonymous.input }
+  it { assert_equal [{a: 1}, {b: 2}], Test.new(:a).test_0002_anonymous.input }
+
+  # returns result.
+  it do
+    assert_equal %(#<struct DeprecationHelperTest::Song::Result input=[{}], success=true>),
+                 Test.new(:a).test_0003_anonymous.inspect
+  end
+  # raises error
+  it { assert_instance_of Trailblazer::Test::Deprecation::OperationFailedError, Test.new(:a).test_0004_anonymous }
+
+  it do
+    assert_equal %(#<struct DeprecationHelperTest::Song::Result input=[{:title=>"Shipwreck"}], success=false>),
+                 Test.new(:a).test_0005_anonymous.inspect
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,6 +21,8 @@ Minitest::Spec.class_eval do
       @errors = errors
     end
 
+    attr_reader :errors
+
     def success?
       @success
     end
@@ -33,6 +35,10 @@ Minitest::Spec.class_eval do
       return @model if name == :model
       return @errors if name == "contract.default"
       return @errors.policy if name == "result.policy.default"
+    end
+
+    def wtf?
+      puts "Operation trace"
     end
   end
 
@@ -65,6 +71,10 @@ Minitest::Spec.class_eval do
 
         Result.new(false, nil, Errors.new(band: ["must be Rancid"]))
       end
+    end
+
+    def self.trace(params:)
+      call(params: params)
     end
   end
 


### PR DESCRIPTION
The only difference between `call` and `trace` are:
- trace will raise an error in case of operation fails
- trace will print the trace in case of failure
- trace will also add a validation error message when raising the `OperationFailedError` but only from `result["contract.default"]`

Both of them will accept a block.