### PR TITLE
Add helper to mock activity or nested activity step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
-before_install:
-  - gem install bundler
+cache: bundler
 matrix:
   include:
     - rvm: 2.1
@@ -13,4 +12,3 @@ matrix:
       gemfile: Gemfile
     - rvm: 2.5.0
       gemfile: Gemfile
-      script: bundle exec rake test && rake rubocop

--- a/lib/trailblazer/test/operation/helper.rb
+++ b/lib/trailblazer/test/operation/helper.rb
@@ -8,6 +8,22 @@ module Trailblazer::Test::Operation
       call!(operation_class, args.merge(raise_on_failure: true), &block)
     end
 
+    def mock_step(operation_class, id:, subprocess: nil, subprocess_path: nil)
+      raise ArgumentError, "Missing block: `mock_step` requires a block." unless block_given?
+
+      block = ->(ctx, **) { yield(ctx) }
+
+      # If deeply nested step needs to be mocked, use the `patch` provided by Subprocess
+      if subprocess
+        return Class.new(operation_class) do
+          patch = { subprocess_path => ->() { step block, replace: id, id: id } }
+          step Subprocess(subprocess, patch: patch), replace: subprocess, id: subprocess
+        end
+      end
+
+      Class.new(operation_class) { step block, replace: id, id: id }
+    end
+
     # @private
     def call!(operation_class, raise_on_failure: false, **args)
       operation_class.trace(**args).tap do |result|

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -69,4 +69,67 @@ class HelperTest < Minitest::Spec
       end
     end
   end
+
+  describe "#mock_step" do
+    implementing = Testing.def_steps(:a, :b, :c, :d)
+
+    deeply_nested = Class.new(Activity::Railway) do
+      step implementing.method(:c), id: :c
+    end
+
+    nested = Class.new(Activity::Railway) do
+      step implementing.method(:b), id: :b
+      step Subprocess(deeply_nested)
+    end
+
+    activity = Class.new(Activity::Railway) do
+      step implementing.method(:a), id: :a
+      step Subprocess(nested)
+      step implementing.method(:d), id: :d
+    end
+
+    it "allows to mock any step" do
+      new_activity = mock_step(activity, id: :a) do |ctx|
+        ctx[:seq] << :mocked_a
+      end
+
+      _, (ctx, _) = new_activity.(seq: [])
+      assert_equal ctx[:seq], [:mocked_a, :b, :c, :d]
+    end
+
+    it "allows to mock any nested activity" do
+      new_activity = mock_step(activity, id: nested) do |ctx|
+        ctx[:seq] << :mocked_nested
+      end
+
+      _, (ctx, _) = new_activity.(seq: [])
+      assert_equal ctx[:seq], [:a, :mocked_nested, :d]
+    end
+
+    it "allows to mock any step within nested activity" do
+      new_activity = mock_step(activity, id: :b, subprocess: nested) do |ctx|
+        ctx[:seq] << :mocked_b
+      end
+
+      _, (ctx, _) = new_activity.(seq: [])
+      assert_equal ctx[:seq], [:a, :mocked_b, :c, :d]
+    end
+
+    it "allows to mock any deeply nested step within nested activity" do
+      new_activity = mock_step(activity, id: :c, subprocess: nested, subprocess_path: [deeply_nested]) do |ctx|
+        ctx[:seq] << :mocked_c
+      end
+
+      _, (ctx, _) = new_activity.(seq: [])
+      assert_equal ctx[:seq], [:a, :b, :mocked_c, :d]
+    end
+
+    it "raises an exception if step's block is not given" do
+      exception = assert_raises ArgumentError do
+        mock_step(activity, id: :a)
+      end
+
+      assert_equal exception.message, "Missing block: `mock_step` requires a block."
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,12 @@ require "trailblazer/test"
 
 require "minitest/autorun"
 
+require "trailblazer/activity/dsl/linear"
+require "trailblazer/activity/testing"
+
+Activity  = Trailblazer::Activity
+Testing   = Trailblazer::Activity::Testing
+
 Minitest::Spec.class_eval do
   include Trailblazer::Test::Assertions
   include Trailblazer::Test::Operation::Assertions

--- a/trailblazer-test.gemspec
+++ b/trailblazer-test.gemspec
@@ -21,9 +21,12 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "hashie"
 
-  spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "simplecov"
+
+  spec.add_dependency "trailblazer-activity", ">= 0.10.0"
+  spec.add_dependency "trailblazer-activity-dsl-linear", ">= 0.2.5"
 end


### PR DESCRIPTION
This adds the ability to mock any step (no matter how nested) for given activity without making any patches to original activity.

```ruby
class Show < Trailblazer::Operation
  step :load_user
  # Some logic to load user
end

new_activity = mock_step(Show, id: :load_user) do |ctx|
  ctx[:user] = double(:user, name: 'Mocky')
end

assert_pass new_activity, {}, {}, do |ctx|
  assert_equal ctx[:user].name, 'Mocky'
end
```