### PR TITLE
Ruby 3.0 compatibility

### DIFF
--- a/lib/trailblazer/test/operation/helper.rb
+++ b/lib/trailblazer/test/operation/helper.rb
@@ -1,11 +1,11 @@
 module Trailblazer::Test::Operation
   module Helper
     def call(operation_class, **args, &block)
-      call!(operation_class, args, &block)
+      call!(operation_class, **args, &block)
     end
 
     def factory(operation_class, **args, &block)
-      call!(operation_class, args.merge(raise_on_failure: true), &block)
+      call!(operation_class, **args.merge(raise_on_failure: true), &block)
     end
 
     def mock_step(operation_class, id:, subprocess: nil, subprocess_path: nil)


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

From ruby 3.0, positional and keyword arguments are separated, so we need to use double splat explicitly for these lines